### PR TITLE
Update flux docs to use stop_time instead of sunset_time

### DIFF
--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -16,9 +16,9 @@ The `flux` switch platform will change the temperature of your lights similar to
 
 The integration will update your lights based on the time of day. It will only affect lights that are turned on and listed in the flux configuration.
 
-During the day (in between `start_time` and `sunset_time`), it will fade the lights from the `start_colortemp` to the `sunset_colortemp`. After sunset (between `sunset_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. If the lights are still on after the `stop_time` it will continue to change the light to the `stop_colortemp` until the light is turned off. The fade effect is created by updating the lights periodically.
+During the day (in between `start_time` and `stop_time`), it will fade the lights from the `start_colortemp` to the `sunset_colortemp`. After sunset (between `stop_time` and `stop_time`), the lights will fade from the `sunset_colortemp` to the `stop_colortemp`. If the lights are still on after the `stop_time` it will continue to change the light to the `stop_colortemp` until the light is turned off. The fade effect is created by updating the lights periodically.
 
-The value of `sunset_time` is automatically calculated based on the location specified in your [Home Assistant configuration](/docs/configuration/basic).
+The value of `stop_time` is automatically calculated based on the location specified in your [Home Assistant configuration](/docs/configuration/basic).
 
 The color temperature is specified in kelvin, and accepted values are between 1000 and 40000 kelvin. Lower values will seem more red, while higher will look more white.
 


### PR DESCRIPTION
`sunset_time` is not a configuration variable used by flux, but `stop_time` is, and it has the behavior described.